### PR TITLE
Feature/DBAAS-1098 image version information in log

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 IMAGE_NAME := mariadb/maxscale
-VERSION := 2.3.4-0
+VERSION := 2.3.9-0
 DEV_SUFFIX ?=
 
 ifneq ($(DEV_SUFFIX), )

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+IMAGE_NAME := mariadb/maxscale
+VERSION := 2.3.0
+DEV_SUFFIX ?=
+
+ifneq ($(DEV_SUFFIX), )
+  LOCAL_IMAGE := $(IMAGE_NAME):$(VERSION)-dev-$(DEV_SUFFIX)-$(shell git rev-parse --short=6 HEAD)
+else
+  LOCAL_IMAGE := $(IMAGE_NAME):$(VERSION)
+endif
+
+.PHONY: help
+
+help:
+	@echo "Usage: make build-image [DEV_SUFFIX=<image suffix>]"
+
+build-image:
+	docker build -f maxscale/Dockerfile . -t $(LOCAL_IMAGE) --build-arg VERSION=$(VERSION) --build-arg GIT_COMMIT=$(shell git rev-list -1 HEAD) --build-arg GIT_TREE_STATE=$(shell (git status --porcelain | grep -q .) && echo -dirty) --build-arg BUILD_TIME=$(shell date -u +%Y-%m-%d_%H:%M:%S)

--- a/Makefile
+++ b/Makefile
@@ -14,4 +14,4 @@ help:
 	@echo "Usage: make build-image [DEV_SUFFIX=<image suffix>]"
 
 build-image:
-	docker build -f maxscale/Dockerfile . -t $(LOCAL_IMAGE) --build-arg VERSION=$(VERSION) --build-arg GIT_COMMIT=$(shell git rev-list -1 HEAD) --build-arg GIT_TREE_STATE=$(shell (git status --porcelain | grep -q .) && echo -dirty) --build-arg BUILD_TIME=$(shell date -u +%Y-%m-%d_%H:%M:%S)
+	docker build -f maxscale/Dockerfile maxscale -t $(LOCAL_IMAGE) --build-arg VERSION=$(VERSION) --build-arg GIT_COMMIT=$(shell git rev-list -1 HEAD) --build-arg GIT_TREE_STATE=$(shell (git status --porcelain | grep -q .) && echo -dirty) --build-arg BUILD_TIME=$(shell date -u +%Y-%m-%d_%H:%M:%S)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 IMAGE_NAME := mariadb/maxscale
-VERSION := 2.3.0
+VERSION := 2.3.4-0
 DEV_SUFFIX ?=
 
 ifneq ($(DEV_SUFFIX), )

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This Docker image runs the latest 2.3 version of MariaDB MaxScale.
 Run the following command in this directory to build the image.
 
 ```
-docker build -t mariadb/maxscale .
+make build-image
 ```
 
 ## Running

--- a/maxscale/Dockerfile
+++ b/maxscale/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get -y update && \
     apt-get -y install maxscale && \
     rm -rf /var/lib/apt/lists/* && \
     if [ ! -z $VERSION ] && [ ! -z $GIT_COMMIT ] && [ ! -z $BUILD_TIME ]; then \
-       echo "Version:    $VERSION\nGit commit: $GIT_COMMIT$GIT_TREE_STATE\nBuilt:      $BUILD_TIME" > /opt/image_details; fi
+       printf "Version:    $VERSION\nGit commit: $GIT_COMMIT$GIT_TREE_STATE\nBuilt:      $BUILD_TIME\n" > /opt/image_details; fi
 
 COPY maxscale.cnf /etc/
 ENTRYPOINT ["maxscale", "-d", "-U", "maxscale", "-l", "stdout"]

--- a/maxscale/Dockerfile
+++ b/maxscale/Dockerfile
@@ -1,6 +1,11 @@
 # Dockerfile for the 2.3 GA version of MariaDB MaxScale
 FROM ubuntu:bionic
 
+ARG VERSION
+ARG GIT_COMMIT
+ARG GIT_TREE_STATE
+ARG BUILD_TIME
+
 COPY maxscale.list /etc/apt/sources.list.d/maxscale.list.tmp
 
 RUN apt-get -y update && \
@@ -9,7 +14,9 @@ RUN apt-get -y update && \
     mv /etc/apt/sources.list.d/maxscale.list.tmp /etc/apt/sources.list.d/maxscale.list && \
     apt-get -y update && \
     apt-get -y install maxscale && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* && \
+    if [ ! -z $VERSION ] && [ ! -z $GIT_COMMIT ] && [ ! -z $BUILD_TIME ]; then \
+       echo "Version:    $VERSION\nGit commit: $GIT_COMMIT$GIT_TREE_STATE\nBuilt:      $BUILD_TIME" > /opt/image_details; fi
 
 COPY maxscale.cnf /etc/
 ENTRYPOINT ["maxscale", "-d", "-U", "maxscale", "-l", "stdout"]


### PR DESCRIPTION
- Changed the Dockerfile to optionally include image version information in the `/opt/image_details` file
- Added a Makefile to build images with this additional information