### PR TITLE
Install missing package ca-certificates

### DIFF
--- a/maxscale/Dockerfile
+++ b/maxscale/Dockerfile
@@ -9,7 +9,7 @@ ARG BUILD_TIME
 COPY maxscale.list /etc/apt/sources.list.d/maxscale.list.tmp
 
 RUN apt-get -y update && \
-    apt-get -y install gnupg2 && \
+    apt-get -y install gnupg2 ca-certificates && \
     apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys "0x135659e928c12247" && \
     mv /etc/apt/sources.list.d/maxscale.list.tmp /etc/apt/sources.list.d/maxscale.list && \
     apt-get -y update && \


### PR DESCRIPTION
Install APT package **ca-certificates** to avoid error about untrusted certificates:

```
  Certificate verification failed: The certificate is NOT trusted. The certificate issuer is unknown.  Could not handshake: Error in the certificate verification. [IP: 104.20.158.76 443]
Reading package lists...
W: http://downloads.mariadb.com/MaxScale/2.4.4/ubuntu/dists/bionic/InRelease: No system certificates available. Try installing ca-certificates.
W: http://downloads.mariadb.com/MaxScale/2.4.4/ubuntu/dists/bionic/Release: No system certificates available. Try installing ca-certificates.
E: The repository 'http://downloads.mariadb.com/MaxScale/2.4.4/ubuntu bionic Release' does not have a Release file.
```