### PR TITLE
Add ability to setup custom repository and clear the repository information from Docker image

### DIFF
--- a/maxscale/Dockerfile
+++ b/maxscale/Dockerfile
@@ -3,6 +3,7 @@ FROM centos:8
 
 ENV TINI_VERSION=v0.18.0
 ENV MXS_VERSION=2.5.5
+ARG CLEAR_REPOSITORY
 ARG REPOSITORY
 ARG REPOSITORY_KEY
 
@@ -41,6 +42,11 @@ RUN dnf -y install bind-utils \
     sudo \
     vim \
     wget
+
+# Remove repository configuration
+RUN if [ "${CLEAR_REPOSITORY}" = "true" ]; then \
+        rm /etc/yum.repos.d/mariadb.repo; \
+    fi
 
 # Copy Files To Image
 COPY config/maxscale.cnf /etc/

--- a/maxscale/Dockerfile
+++ b/maxscale/Dockerfile
@@ -3,6 +3,8 @@ FROM centos:8
 
 ENV TINI_VERSION=v0.18.0
 ENV MXS_VERSION=2.5.5
+ARG REPOSITORY
+ARG REPOSITORY_KEY
 
 # Add Tini Init Process
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /usr/bin/tini
@@ -10,9 +12,17 @@ ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /usr/
 # Add Repo Setup script
 ADD https://downloads.mariadb.com/MariaDB/mariadb_repo_setup /tmp/mariadb_repo_setup
 
+# Add script to setup the private repository
+COPY scripts/setup-custom-repository.sh /tmp/setup-custom-repository.sh
+
 # Install MariaDB Repositories
-RUN chmod +x /tmp/mariadb_repo_setup && \
-    /tmp/mariadb_repo_setup --mariadb-maxscale-version=${MXS_VERSION}
+RUN if [ -z "${REPOSITORY}" ]; then \
+        chmod +x /tmp/mariadb_repo_setup && \
+        /tmp/mariadb_repo_setup --mariadb-maxscale-version=${MXS_VERSION}; \
+    else \
+        chmod +x /tmp/setup-custom-repository.sh && \
+        /tmp/setup-custom-repository.sh --repository ${REPOSITORY} --repository-key ${REPOSITORY_KEY}; \
+    fi
 
 # Update System
 RUN dnf -y install epel-release && \

--- a/maxscale/scripts/setup-custom-repository.sh
+++ b/maxscale/scripts/setup-custom-repository.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+usage() {
+  echo <<INFO "$(basename "${0}")" --repository REPOSITORY --repository-key KEY
+
+    --repository REPOSITORY path to the MaxScale repository
+    --repository-key KEY               URL to the repository key
+INFO
+}
+
+repository=
+key=
+
+while [[ ${1:-} ]]; do
+  case "$1" in
+    "--repository")
+      shift
+      repository="$1"
+      shift
+      ;;
+    "--repository-key")
+      shift
+      key=$1
+      shift
+      ;;
+    "--help")
+      usage
+      exit
+      ;;
+    *)
+      echo "unknown option $1"
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z $repository ]]; then
+  echo "Please specify path to the repository via --repository"
+  exit 1
+fi
+
+if [[ -z $key ]]; then
+  echo "Please specify the URL to the repository key via --key"
+  exit 1
+fi
+
+echo 'Adding repository signing key'
+if rpm --import "${key}"
+then
+  echo 'Successfully added package signing key'
+else
+  echo 'Failed to add package signing key'
+fi
+
+echo 'Configuring repository'
+echo "[mariadb-maxscale]
+name = MariaDB MaxScale
+baseurl = $repository
+gpgcheck = 1
+enabled = 1" > /etc/yum.repos.d/mariadb.repo


### PR DESCRIPTION
The main purpose for these changes is to use the Dockerfile for CI purposes. MaxScale CI repositories are located in private repositories, that are not accessible using mariadb_repo_setup script.

I am contributing the new code of the whole pull request, including one or
several files that are either new files or modified ones, under the BSD-new
license.
