### PR TITLE
[docker-compose] bump maxscale version to 2.5 & enable admin web GUI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 IMAGE_NAME := mariadb/maxscale
-VERSION := 2.4.11-1
+VERSION := 2.4.12-1
 DEV_SUFFIX ?=
 
 ifneq ($(DEV_SUFFIX), )

--- a/maxscale/Dockerfile
+++ b/maxscale/Dockerfile
@@ -11,7 +11,7 @@ COPY maxscale.list /etc/apt/sources.list.d/maxscale.list.tmp
 
 RUN apt-get -y update && \
     apt-get -y install gnupg2 ca-certificates less sysstat && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys "0x135659e928c12247" && \
+    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys "0xE3C94F49" && \
     mv /etc/apt/sources.list.d/maxscale.list.tmp /etc/apt/sources.list.d/maxscale.list && \
     apt-get -y update && \
     apt-get -y install maxscale && \

--- a/maxscale/docker-compose.yml
+++ b/maxscale/docker-compose.yml
@@ -35,14 +35,17 @@ services:
             - "4003:3306"
 
     maxscale:
-        image: mariadb/maxscale:2.4
+        image: mariadb/maxscale:2.5
         depends_on:
             - master
             - slave1
             - slave2
         volumes:
             - ./maxscale.cnf.d:/etc/maxscale.cnf.d
+            - ./maxscale.cnf:/etc/maxscale.cnf
         ports:
             - "4006:4006"  # readwrite port
             - "4008:4008"  # readonly port
             - "8989:8989"  # REST API port
+        restart: on-failure
+

--- a/maxscale/maxscale.cnf
+++ b/maxscale/maxscale.cnf
@@ -7,6 +7,7 @@
 # Global parameters
 
 [maxscale]
+admin_secure_gui=false
 threads=auto
 # this enables external access to the REST API outside of localhost
 # please review / modify for any public / non development environments

--- a/maxscale/maxscale.list
+++ b/maxscale/maxscale.list
@@ -1,5 +1,5 @@
 # MariaDB MaxScale
 # To use the latest stable release of MaxScale, use "latest" as the version
 # To use the latest beta (or stable if no current beta) release of MaxScale, use "beta" as the version
-deb http://downloads.mariadb.com/MaxScale/2.4.11/ubuntu bionic main
+deb http://downloads.mariadb.com/MaxScale/2.4.12/ubuntu bionic main
 


### PR DESCRIPTION
- bump maxscale version to 2.5
- include main config to docker volume
- enable restart on maxscale failed to start
- enable admin GUI via web browser on http://localhost:8989/

I am contributing the new code of the whole pull request, including one or
several files that are either new files or modified ones, under the BSD-new
license.
