### PR TITLE
Use multi-staged build to hide all the file system operations and arguments that are passed during the build of an image

### DIFF
--- a/maxscale/Dockerfile
+++ b/maxscale/Dockerfile
@@ -1,5 +1,5 @@
 # vim:set ft=dockerfile:
-FROM centos:8
+FROM centos:8 as base
 
 ENV TINI_VERSION=v0.18.0
 ENV MXS_VERSION=2.5.6
@@ -64,15 +64,6 @@ RUN chmod +x /usr/bin/tini \
     /usr/bin/maxscale-stop \
     /usr/bin/maxscale-restart
 
-# Expose MariaDB Port
-EXPOSE 3306
-
-# Expose REST API port
-EXPOSE 8989
-
-# Create Persistent Volume
-VOLUME ["/var/lib/maxscale"]
-
 # Copy Entrypoint To Image
 COPY scripts/docker-entrypoint.sh /usr/bin/
 
@@ -90,6 +81,19 @@ RUN dnf clean all && \
     find /var/log -type f -exec cp /dev/null {} \; && \
     cat /dev/null > ~/.bash_history && \
     history -c
+
+# Clear the build history
+FROM scratch
+COPY --from=base / /
+
+# Expose MariaDB Port
+EXPOSE 3306
+
+# Expose REST API port
+EXPOSE 8989
+
+# Create Persistent Volume
+VOLUME ["/var/lib/maxscale"]
 
 # Start Up
 ENTRYPOINT ["/usr/bin/tini","--","docker-entrypoint.sh"]


### PR DESCRIPTION
In previous PR I have added an ability to use private CI repository. Unfortunately all passed arguments are saved into the image history.

In this PR the following changes are made:
1. All file system operations are done in the first stage, base stage.
2. The complete file system is then copied into the scratch (empty) container.
3. The resulting image is configured with the runtime options.

The downside for this approach: the users will have to download the whole image to receive the updated version of the MaxScale. On the bright side: during the build all Docker caching logic still applies.

I am contributing the new code of the whole pull request, including one or
several files that are either new files or modified ones, under the BSD-new
license.
