### PR TITLE
add dnf clean before Maxscale installation

### DIFF
--- a/maxscale/Dockerfile
+++ b/maxscale/Dockerfile
@@ -30,7 +30,8 @@ RUN dnf -y install epel-release && \
     dnf -y upgrade
 
 # Install Some Basic Dependencies & MaxScale
-RUN dnf -y install bind-utils \
+RUN dnf clean expire-cache && \
+    dnf -y install bind-utils \
     less \
     maxscale \
     monit \


### PR DESCRIPTION
image build fails sometimes without without `dnf clean expire-cache` 

Please port this change to all other branches