### PR TITLE
added tailing maxscale logs

### DIFF
--- a/maxscale/scripts/docker-entrypoint.sh
+++ b/maxscale/scripts/docker-entrypoint.sh
@@ -6,11 +6,24 @@ function exitMaxScale {
     /usr/bin/monit quit
 }
 
+waitForLogFile() {
+    local file="$1"
+    while [[ ! -r "$file" ]]; do
+        sleep 1
+    done
+}
+
 rm -f /var/run/*.pid
 rsyslogd
 
 trap exitMaxScale SIGTERM
 
 exec "$@" &
+
+# Wait for the maxscale.log to be readable
+waitForLogFile /var/log/maxscale/maxscale.log
+
+tail -f /var/log/maxscale/maxscale.log
+
 
 wait


### PR DESCRIPTION
I am contributing the new code of the whole pull request, including one or
several files that are either new files or modified ones, under the BSD-new
license.

This change adds the logging of /var/log/maxscale/maxscale.log. This is very valuable in production environment especially when running in Kubernetes.