### PR TITLE
Bump preflight version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ $(LOCALBIN):
 ## Tool Binaries
 PREFLIGHT ?= $(LOCALBIN)/preflight
 ## Tool Versions
-PREFLIGHT_VERSION ?= 1.9.1
+PREFLIGHT_VERSION ?= 1.9.6
 
 .PHONY: help
 


### PR DESCRIPTION
I am contributing the new code of the whole pull request, including one or
several files that are either new files or modified ones, under the BSD-new
license.

OpenShift preflight 1.9.1 is no longer supported and it is returning the following error when building images:
https://github.com/mariadb-corporation/maxscale-docker/actions/runs/9362565433/job/25771545679