### PR TITLE
Bump UBI minimal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1161
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1018
 
 ARG MXS_VERSION
 


### PR DESCRIPTION
Our current UBI version presents vulnerabilities related to glibc that can be fixed by bumping to the latest UBI version:
- https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8?image=660383f31ba64b6bd44df0a7&container-tabs=security


This PR bumps UBI minimal to the latest version, which has a health index of A and no known vulnerabilities:
- https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8?container-tabs=security

