### PR TITLE
Support for running preflight with multiple tags

### DIFF
--- a/.github/workflows/release-ubi.yml
+++ b/.github/workflows/release-ubi.yml
@@ -57,7 +57,12 @@ jobs:
             org.opencontainers.image.version=${{ github.event.inputs.version }}
 
       - name: Preflight image
-        run: make preflight-image-submit
+        run: |
+          IFS=',' read -r -a TAGS_ARRAY <<< "${{ github.event.inputs.tags }}"
+          for TAG in "${TAGS_ARRAY[@]}"; do
+            echo "Running preflight for \"$TAG\""
+            PREFLIGHT_IMAGE="$TAG" make preflight-image-submit 
+          done
         env:
           MXS_VERSION: "${{ github.event.inputs.version }}"
           REDHAT_API_KEY: "${{ secrets.REDHAT_API_KEY }}"

--- a/Makefile
+++ b/Makefile
@@ -27,13 +27,14 @@ help:
 build-image:
 	docker build -f Dockerfile -t $(IMAGE_TAG) --build-arg MXS_VERSION=$(MXS_VERSION) .
 
+PREFLIGHT_IMAGE ?= ""
 .PHONY: preflight-image
 preflight-image: preflight ## Run preflight tests on the image.
-	$(PREFLIGHT) check container $(IMAGE_TAG) --docker-config $(DOCKER_CONFIG)
+	$(PREFLIGHT) check container $(PREFLIGHT_IMAGE) --docker-config $(DOCKER_CONFIG)
 
 .PHONY: preflight-image-submit
 preflight-image-submit: preflight ## Run preflight tests on the image and submit the results to Red Hat.
-	$(PREFLIGHT) check container $(IMAGE_TAG)\
+	$(PREFLIGHT) check container $(PREFLIGHT_IMAGE)\
 		--submit \
 		--pyxis-api-token=$(REDHAT_API_KEY) \
 		--certification-project-id=$(REDHAT_PROJECT_ID)\


### PR DESCRIPTION
The MaxScale version provided via the input `version` doesn't necessarily match the tags. For this reason, we should run preflight based on the `tags` input instead.

I've been testing this on my fork:

|      version       | tags | workflow|
|------------|-------|------------|
| 23.08.6 | mariadbmmontes/maxscale:23.08-ubi,mariadbmmontes/maxscale:23.08.6-ubi-1 | https://github.com/mariadb-mmontes/maxscale-docker/actions/runs/10389905281|
| 23.08.6 | mariadbmmontes/maxscale:23.08-ubi| https://github.com/mariadb-mmontes/maxscale-docker/actions/runs/10389987158/job/28769369993|

The images have been successfuly pushed to [my registry](https://hub.docker.com/r/mariadbmmontes/maxscale/tags) and the preflight results appear on the RedHat portal.