### PR TITLE
Bump preflight to 1.9.9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ $(LOCALBIN):
 ## Tool Binaries
 PREFLIGHT ?= $(LOCALBIN)/preflight
 ## Tool Versions
-PREFLIGHT_VERSION ?= 1.9.6
+PREFLIGHT_VERSION ?= 1.9.9
 
 .PHONY: help
 


### PR DESCRIPTION
I am contributing the new code of the whole pull request, including one or
several files that are either new files or modified ones, under the BSD-new
license.

Our current 1.9.6 version of preflight is deprecated:
```bash
error: 'github.com/redhat-openshift-ecosystem/openshift-preflight' version '1.9.6' is not supported. Supported versions are: ['1.10.0', '1.9.7', '1.9.8', '1.9.9']", "status": 400, "trace_id": "0x7fdedf318328c87465b354d183294d4d"}
make: *** [Makefile:37: preflight-image-submit] Error 1
Error: Process completed with exit code 2.
```
This PR bumps it to the latest version.